### PR TITLE
remove unnecessary list materialisation

### DIFF
--- a/convert2dfa.py
+++ b/convert2dfa.py
@@ -284,7 +284,7 @@ def atom2letters(atom_string, letter2pos, is_word):
 					new_letter_list.append(l+[0])
 			letter_list = new_letter_list
 
-		letter_list = set([tuple(l) for l in letter_list])
+		letter_list = set(tuple(l) for l in letter_list)
 		all_letter_list= all_letter_list.union(letter_list)
 	
 	return list(all_letter_list)

--- a/directed_ltl.py
+++ b/directed_ltl.py
@@ -229,12 +229,12 @@ class findDltl:
 		
 		#Calculates the maximum length of the traces
 		try:
-			self.max_positive_length = max([len(trace) for trace in self.sample.positive])
+			self.max_positive_length = max(len(trace) for trace in self.sample.positive)
 		except:
 			self.max_positive_length = 0
 
 		try:
-			self.max_negative_length = max([len(trace) for trace in self.sample.negative])
+			self.max_negative_length = max(len(trace) for trace in self.sample.negative)
 		except:
 			self.max_negative_length = 0
 		'''
@@ -743,7 +743,7 @@ class findDltl:
 		for length in dltl_lengths:
 		
 			for dltl in self.len_dltl[(sl_length, width-1)][length]:
-				min_w1_length = length - sum([len_atom(atom,dltl.inv) for atom in dltl.vector[1::2]]) + sl_length
+				min_w1_length = length - sum(len_atom(atom,dltl.inv) for atom in dltl.vector[1::2]) + sl_length
 				max_w1_length = min_w1_length + sl_length
 
 				for w1_length in range(min_w1_length, max_w1_length+1):

--- a/sample.py
+++ b/sample.py
@@ -15,7 +15,7 @@ def lineToTrace(line):
 		traceData, lasso_start = line.split('::')
 	except:
 		traceData = line
-	trace_vector = [tuple([int(varValue) for varValue in varsInTimestep.split(',')]) for varsInTimestep in
+	trace_vector = [tuple(int(varValue) for varValue in varsInTimestep.split(',')) for varsInTimestep in
 				   traceData.split(';')]
 
 	return (trace_vector, lasso_start)
@@ -49,12 +49,12 @@ def convertFileType(operators, wordfile, tracefile=None):
 		tracefile = wordfile.rstrip('.words')+'.trace'
 	with open(tracefile, 'w') as file:
 		for word in sample.positive:
-			prop_word = ';'.join([','.join(one_hot_alphabet[letter]) for letter in word.vector])
+			prop_word = ';'.join(','.join(one_hot_alphabet[letter]) for letter in word.vector)
 			file.write(prop_word+'\n')
 
 		file.write('---\n')
 		for word in sample.negative:
-			prop_word = prop_word = ';'.join([','.join(one_hot_alphabet[letter]) for letter in word.vector])
+			prop_word = prop_word = ';'.join(','.join(one_hot_alphabet[letter]) for letter in word.vector)
 			file.write(prop_word+'\n')
 		file.write('---\n')
 		file.write(','.join(operators))
@@ -161,7 +161,7 @@ class Trace:
 				val = min([self.truthValue(formula.left, futureTimestep, letter2pos) for futureTimestep in futureTracePositions])			
 			elif label == 'U':
 				val = max(
-					[self.truthValue(formula.right, futureTimestep, letter2pos) for futureTimestep in futureTracePositions]) == True \
+					self.truthValue(formula.right, futureTimestep, letter2pos) for futureTimestep in futureTracePositions) == True \
 					   and ( \
 								   self.truthValue(formula.right, timestep, letter2pos) \
 								   or \
@@ -186,7 +186,7 @@ class Trace:
 
 	def __str__(self):
 		vector_str = [list(map(lambda x: str(int(x)), letter)) for letter in self.vector]
-		return str(';'.join([','.join(letter) for letter in vector_str]))
+		return str(';'.join(','.join(letter) for letter in vector_str))
 	
 	def __len__(self):
 		 return self.length
@@ -549,7 +549,7 @@ class Sample:
 		num_accepted_words_length = {}
 		num_words_per_length = {}
 		for i in range(length_range[0], length_range[1]+1):
-			num_accepted_words_length[i] = sum([dfa.number_of_words[(dfa.init_state,i)] for dfa in ltldfa_list])
+			num_accepted_words_length[i] = sum(dfa.number_of_words[(dfa.init_state,i)] for dfa in ltldfa_list)
 		
 		total_accepted_words = sum(num_accepted_words_length.values())
 		for i in range(length_range[0], length_range[1]):
@@ -596,7 +596,7 @@ class Sample:
 		num_accepted_words_length = {}
 		num_words_per_length = {}
 		for i in range(length_range[0], length_range[1]+1):
-			num_accepted_words_length[i] = sum([dfa.number_of_words[(dfa.init_state,i)] for dfa in ltldfa_list])
+			num_accepted_words_length[i] = sum(dfa.number_of_words[(dfa.init_state,i)] for dfa in ltldfa_list)
 		
 		total_accepted_words = sum(num_accepted_words_length.values())
 		for i in range(length_range[0], length_range[1]):

--- a/tests/test_learner/test_dltl.py
+++ b/tests/test_learner/test_dltl.py
@@ -41,14 +41,14 @@ def test_genPossibleAtoms(test_num, prop_list):
 	
 	f = findDltl(sample = Sample(), operators=['F','G','X','&','|','!'], last=False, thres=0, upper_bound=30)
 	rand_inv = random.choice([True, False])
-	rand_letter = tuple([random.randint(0,1) for _ in range(len(prop_list))])
+	rand_letter = tuple(random.randint(0,1) for _ in range(len(prop_list)))
 	print(rand_letter)
 	assert f.genPossibleAtoms(letter=rand_letter, width=0, inv=rand_inv, is_end=False) == [] #there are no width 0 atoms 
 	
 	# testing via length check
 	n = len(prop_list)
 	for k in range(1,n+1):
-		assert len(f.genPossibleAtoms(letter=rand_letter, width=k, inv=rand_inv,  is_end=False)) == sum([comb(n,i) for i in range(1,k+1)])
+		assert len(f.genPossibleAtoms(letter=rand_letter, width=k, inv=rand_inv,  is_end=False)) == sum(comb(n,i) for i in range(1,k+1))
 
 
 
@@ -66,7 +66,7 @@ def test_extenddltl(test_num, prop_list):
 
 	for i in range(5):
 		rand_diff = random.randint(0,3)
-		rand_letter = tuple([random.randint(0,1) for _ in range(len(prop_list))])
+		rand_letter = tuple(random.randint(0,1) for _ in range(len(prop_list)))
 		rand_width = random.randint(1,len(prop_list)) if len(prop_list)>1 else 1
 		rand_atoms = f.genPossibleAtoms(letter=rand_letter, width=rand_width, inv=False, is_end=False)
 		try:
@@ -108,7 +108,7 @@ def test_add2dltl(test_num, prop_list):
 		dltl1_tuple = tuple()
 		dltl2_tuple = tuple()
 		for i in range(rand_len):
-			rand_letter = tuple([random.randint(0,1) for _ in range(len(prop_list))])
+			rand_letter = tuple(random.randint(0,1) for _ in range(len(prop_list)))
 			rand_atom1 = random.choice(f.genPossibleAtoms(letter=rand_letter, width=1, inv=False, is_end=False))
 
 			rand_width = random.randint(1,len(prop_list)) if len(prop_list)>1 else 1
@@ -177,7 +177,7 @@ def test_R_table(test_file):
 		for d in R_table:
 			assert len(d.vector) == 2*length
 			atoms = d.vector[1::2]
-			max_len_atom =  max([len(a) for a in atoms])
+			max_len_atom =  max(len(a) for a in atoms)
 			assert max_len_atom == width
 
 
@@ -196,7 +196,7 @@ def test_dltlCoverSet(test_num, test_file):
 	dltl_tuple = tuple()
 	rand_len = random.randint(1,5)
 	for i in range(rand_len):
-		rand_letter = tuple([random.randint(0,1) for _ in range(len(sample.alphabet))])
+		rand_letter = tuple(random.randint(0,1) for _ in range(len(sample.alphabet)))
 		rand_width = random.randint(1,len(sample.alphabet)) if len(sample.alphabet)>1 else 1
 		rand_atom = random.choice(f.genPossibleAtoms(letter=rand_letter, width=rand_width, inv=False, is_end=False))
 

--- a/tests/test_learner/test_inferLTL.py
+++ b/tests/test_learner/test_inferLTL.py
@@ -27,7 +27,7 @@ def random_dltl(length):
     for _ in range(length):    
         value = random.choice(['>',''])+str(random.randint(0,5))
         atom = sorted(random.sample([0,1,2],k=random.randint(1,3)))
-        signed_atom = tuple([random.choice(['+','-'])+str(i) for i in atom])
+        signed_atom = tuple(random.choice(['+','-'])+str(i) for i in atom)
         dltl += (value, signed_atom)
 
     return dltl


### PR DESCRIPTION
Functions like `tuple` will accept generator expressions, so there is no need to wrap them in `[]`.